### PR TITLE
fix `alias_method_chain' error with rails3+

### DIFF
--- a/lib/redmine_more_filters/patches/query_patch.rb
+++ b/lib/redmine_more_filters/patches/query_patch.rb
@@ -28,9 +28,7 @@ module RedmineMoreFilters
         base.class_eval do
           unloadable
           
-          alias_method :sql_for_field_without_more_filters, :sql_for_field
-          alias_method :sql_for_field, :sql_for_field_with_more_filters
-          alias_method :more_filters, :sql_for_field
+          alias_method_chain :sql_for_field, :more_filters
           
           self.operators.merge!(
             "^="    => :label_begins_with,

--- a/lib/redmine_more_filters/patches/query_patch.rb
+++ b/lib/redmine_more_filters/patches/query_patch.rb
@@ -28,9 +28,20 @@ module RedmineMoreFilters
         base.class_eval do
           unloadable
           
-          alias_method_chain :sql_for_field, :more_filters
-          alias_method_chain :sql_for_custom_field, :more_filters
-          alias_method_chain :statement, :more_filters
+          #alias_method_chain :sql_for_field, :more_filters
+          alias_method :sql_for_field_without_more_filters, :sql_for_field
+          alias_method :sql_for_field, :sql_for_field_with_more_filters
+          alias_method :more_filters, :sql_for_field
+          
+          #alias_method_chain :sql_for_custom_field, :more_filters
+          alias_method :sql_for_custom_field_without_more_filters, :sql_for_custom_field
+          alias_method :sql_for_custom_field, :sql_for_custom_field_with_more_filters
+          alias_method :more_filters, :sql_for_custom_field
+          
+          #alias_method_chain :statement, :more_filters
+          alias_method :statement_without_more_filters, :statement
+          alias_method :statement, :statement_with_more_filters
+          alias_method :more_filters, :statement
           
           self.operators.merge!(
           

--- a/lib/redmine_more_filters/patches/query_patch.rb
+++ b/lib/redmine_more_filters/patches/query_patch.rb
@@ -28,7 +28,9 @@ module RedmineMoreFilters
         base.class_eval do
           unloadable
           
-          alias_method_chain :sql_for_field, :more_filters
+          alias_method :sql_for_field_without_more_filters, :sql_for_field
+          alias_method :sql_for_field, :sql_for_field_with_more_filters
+          alias_method :more_filters, :sql_for_field
           
           self.operators.merge!(
             "^="    => :label_begins_with,


### PR DESCRIPTION
fix undefined method `alias_method_chain' error with rails3+, redmine4.x

With redmine4, there would be error, because alias_method_chain is not available after rails3.
NoMethodError: undefined method `alias_method_chain'

http://railscasts.com/episodes/232-routing-walkthrough-part-2?view=asciicast
"This technique is used often in the Rails 3 source code. Earlier versions of Rails used alias_method_chain to override specific behaviour, but now in Rails 3 we can just use super."

Tested work well with Redmine4.x, but i didn't test it with Redmine3.x, so please consider review it or leave it there.

This PR fixes issue https://github.com/HugoHasenbein/redmine_more_filters/issues/4