### PR TITLE
allow non-digit seperator for integer for case "is"

### DIFF
--- a/lib/redmine_more_filters/patches/query_patch.rb
+++ b/lib/redmine_more_filters/patches/query_patch.rb
@@ -86,7 +86,12 @@ module RedmineMoreFilters
             if values_for(field)
               case type_for(field)
               when :integer
-                add_filter_error(field, :invalid) if values_for(field).detect {|v| v.present? && !v.match(/\A[+-]?\d+(,[+-]?\d+)*\z/) }
+                case operator_for(field)
+                when "="
+                  add_filter_error(field, :invalid) if values_for(field).detect {|v| v.present? && !v.match(/\A[+-]?\d+(\D*\d+)*\z/) }
+                else
+                  add_filter_error(field, :invalid) if values_for(field).detect {|v| v.present? && !v.match(/\A[+-]?\d+(,[+-]?\d+)*\z/) }
+                end
               when :float
                 add_filter_error(field, :invalid) if values_for(field).detect {|v| v.present? && !v.match(/\A[+-]?\d+(\.\d*)?\z/) }
               when :date, :date_past


### PR DESCRIPTION
normally users will copy the Issue IDs from some other documents and paste them to the textbox to query with multiple Issue IDs.
Currently the original query only allow "," as the seperator, but acutally from excel/csv and some other documents the seperator would be other characters, users will get crazy to replace all of them one by one to ",".
