### PR TITLE
Added 'Descendant of' filter for issues to show all descendants

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,4 +72,6 @@ en:
   
   label_all_relations:                                "All related to"
 
+  label_descendant_of:                                "Descendant of"
+
   field_root:                                         "Root"

--- a/lib/redmine_more_filters/patches/issue_query_patch.rb
+++ b/lib/redmine_more_filters/patches/issue_query_patch.rb
@@ -72,6 +72,12 @@ module RedmineMoreFilters
             :type  => :integer, 
             :label => :label_all_relations
             
+
+          add_available_filter("descendant_of",
+            :type => :integer,
+            :label => :label_descendant_of
+          )
+
           add_available_filter("created_on_by_clock_time",
             :type => :time_past
           )
@@ -208,6 +214,11 @@ module RedmineMoreFilters
             sqls = [sql, sql_for_all_relations_field(field, operator, value, :reverse => true)]
             sql = sqls.join(["="].include?(operator) ? " OR " : " AND ")
           end
+          "(#{sql})"
+        end
+
+        def sql_for_descendant_of_field(field, operator, value)
+          sql = "#{Issue.table_name}.id IN ( SELECT DISTINCT i.id FROM #{Issue.table_name} i INNER JOIN #{Issue.table_name} j ON i.root_id = j.root_id AND i.lft > j.lft AND i.rgt < j.rgt WHERE #{sql_for_field("id", "=", value, "j", "id")} )"
           "(#{sql})"
         end
         

--- a/lib/redmine_more_filters/patches/queries_helper_patch.rb
+++ b/lib/redmine_more_filters/patches/queries_helper_patch.rb
@@ -64,7 +64,7 @@ module RedmineMoreFilters
               group = :label_relations
             elsif field_options[:type] == :tree
               group = query.is_a?(IssueQuery) ? :label_relations : nil
-            elsif field =~ /root_id|all_relations/ 
+            elsif field =~ /root_id|all_relations|descendant_of/ 
               group = :label_relations
             elsif field =~ /^cf_\d+\./
               group = (field_options[:through] || field_options[:field]).try(:name)


### PR DESCRIPTION
This adds a "Descendant of" filter under the "Relations" group of the filters drop down, which shows not just the direct children (as does the existing "Parent" filter on the `parent_id` field), and not all issues with the same `root_id` (as does the "Root" filter in this plugin), but all children and sub-children, etc. of a given issue, exclusive of any parent or ancestral issues sharing the same `root_id`.

![Screen Shot 2022-08-16 at 1 34 20 PM](https://user-images.githubusercontent.com/93607/184946715-a5a8b9ff-044d-4d38-ba7e-263864ff0204.png)

I didn't include any non-English translations here because I'm not sure if direct translations of "descendant" are correct in the context of a tree hierarchy. I'd love if someone more familiar with the other languages could add those.